### PR TITLE
Update occupancy notebook to use API key auth

### DIFF
--- a/notebooks/occupancy_bulk_download_generator.ipynb
+++ b/notebooks/occupancy_bulk_download_generator.ipynb
@@ -1,555 +1,619 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
+ "nbformat": 4,
+ "nbformat_minor": 0,
+ "metadata": {
+  "colab": {
+   "provenance": [],
+   "include_colab_link": true
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/vivacitylabs/data-toolkit/blob/master/notebooks/occupancy_bulk_download_generator.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# Occupancy - Bulk Download Generator\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "swMyhc_6p4SZ"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Generate a csv file of zonal occupancy data over multiple days"
-      ],
-      "metadata": {
-        "id": "f4ZN3B2nO3_1"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "This notebook is a tool to access VivaCity data via the API. It is aimed as an **interim solution** while we're working on new dashboard developments. You can contact customer support if you have any issues (support@vivacitylabs.com) or raise a ticked on the [Customer Help Portal](https://vivacitylabs.atlassian.net/servicedesk/customer/portal/16)."
-      ],
-      "metadata": {
-        "id": "rPUGheZbGhnG"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "#### How it works"
-      ],
-      "metadata": {
-        "id": "owGXUfxaRzlG"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "This notebook will run you through all the necessary steps and will save a csv file locally or in your Google Drive.\n",
-        "\n",
-        "You will need to fill in a few details and then hit the run button (▶) next to the code cells.\n",
-        "\n",
-        "If you want to make changes to the code and save them, you will first need to save a copy of this notebook to your Google Drive.\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "waNUJf0ZOFHa"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "**What you will need**\n",
-        "\n",
-        "- VivaCity API login credentials\n",
-        "- Sensors and their zones you want to download data for\n",
-        "\n",
-        "\n",
-        "\n",
-        "ℹ  Note the notebook only works for zones that have [occupancy](https://vivacitylabs.customerly.help/vivacity-dashboard/occupancy) enabled\n"
-      ],
-      "metadata": {
-        "id": "bl3aEsarmxD_"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "#### Output format"
-      ],
-      "metadata": {
-        "id": "Xi8YdeTmRwNr"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "You will receive occupancy measures in selected time buckets in the following format. The mean objects and mean stopped objects per second are derived from the `total_count` and `stopped_count` columns. For an explanation on those, read the API documentation [here](https://beta.docs.api.vivacitylabs.com/)."
-      ],
-      "metadata": {
-        "id": "I9ryHNRfRjWw"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "\n",
-        "| Start Date | Start time | End time | zone_id |  zone_description | \tclass |\ttotal_count|\tstopped_count |\tmean_objects_second |\tmean_stopped_objects_second |\n",
-        "|:---------:|:---------:|:---------:|:---------:|:---------:|:---------:|:---------:|:---------:|:---------:|:---------:|\n",
-        "| 2022-10-17 |00:00:00\t| 00:15:00 |\t2245 | S4 GrandDrive - Zone 1 (2245) | car\t|{'1': 20}|{}|\t0.0056 |\t0.0000\t|\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "lmzYubsdPDFg"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Stage 1: Getting Started\n",
-        "Let's begin by importing the packages we'll need and creating some useful functions!\n",
-        "\n",
-        "Hit the run button (▶) in the top left corner."
-      ],
-      "metadata": {
-        "id": "p-2otBZMqfTH"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "#@title { vertical-output: false, display-mode: \"form\" }\n",
-        "#@markdown **Code cell:** Run this to import functions and connect to Google Drive\n",
-        "import requests\n",
-        "import getpass\n",
-        "import json\n",
-        "from datetime import date, datetime, timedelta\n",
-        "import pytz\n",
-        "import pandas as pd\n",
-        "import csv\n",
-        "import time\n",
-        "from IPython.display import Markdown, display\n",
-        "def printmd(string):\n",
-        "    display(Markdown(string))\n",
-        "from ipywidgets import interact, interactive, fixed, interact_manual, Layout, Box\n",
-        "import ipywidgets as widgets\n",
-        "import warnings\n",
-        "warnings.filterwarnings('ignore')\n",
-        "\n",
-        "def get_date_range(start_date, end_date):\n",
-        "    start_dates = []\n",
-        "    end_dates = []\n",
-        "\n",
-        "    start_date = datetime.fromisoformat(start_date)\n",
-        "    end_date = datetime.fromisoformat(end_date)\n",
-        "    while True:\n",
-        "        start_dates.append(start_date.strftime('%Y-%m-%dT%H:%M:%S.000Z'))\n",
-        "        end_dates.append((start_date+timedelta(days=1)).strftime('%Y-%m-%dT%H:%M:%S.000Z'))\n",
-        "        start_date = start_date+timedelta(days=1)\n",
-        "        if start_date > end_date:\n",
-        "            break\n",
-        "    date_range = list(zip(start_dates, end_dates))\n",
-        "    return date_range"
-      ],
-      "metadata": {
-        "id": "UXc72Xjuqikg"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Stage 2: Data Import\n",
-        "At the end of this process we will requested data from the API for the dates in the range that you have determined in the **Zone Details** step.\n",
-        "\n",
-        "The resulting JSON responses will then be converted into a data table in the **Data Processing** step.\n",
-        "\n",
-        "Authentication is handled at this stage."
-      ],
-      "metadata": {
-        "id": "ceKN_3fHqlP6"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Authentication\n",
-        "Now you will need your API login details, ie. a username and a password. If you don't have one, please contact contact customer support (support@vivacitylabs.com).\n",
-        "\n",
-        "1.   Enter the username into the field on the right, then hit the run button (▶).\n",
-        "2.   Input the password in the box that appears below it and hit \"enter\" on your keyboard.\n"
-      ],
-      "metadata": {
-        "id": "zSCZ0-x1tf0l"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "#@title  { vertical-output: true, display-mode: \"form\" }\n",
-        "#@markdown **Code cell:** Insert your login credentials, then run, enter password + hit enter\n",
-        "username = \"api-username\" #@param {type:\"string\"}\n",
-        "\n",
-        "auth_body = {}\n",
-        "auth_body['username'] = username\n",
-        "auth_body['password'] = getpass.getpass()"
-      ],
-      "metadata": {
-        "id": "i8mP6EzKE-MX"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Retrieve available sensors and zones\n",
-        "\n",
-        "We'll now get an access token using the username and password set above and get all sensors and their zones the api user has access to (which have occupancy enabled)."
-      ],
-      "metadata": {
-        "id": "wEu2avZvwMDx"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "#@title { vertical-output: false, display-mode: \"form\" }\n",
-        "#@markdown **Code cell:** Run this to get authorized access to the API\n",
-        "\n",
-        "print(\"Authorising...\")\n",
-        "auth_response = requests.post(\"https://api.vivacitylabs.com/get-token\", data=auth_body, headers={'Content-Type':'application/x-www-form-urlencoded'})\n",
-        "if auth_response.status_code == 401:\n",
-        "  print(\"\\n!Error: Can't connect to the API. Check your username and password again.\\nIf issues persists, ask customer support if your user is setup correctly on the API\\n\")\n",
-        "else:\n",
-        "  headers = {}\n",
-        "  headers['Authorization'] = \"Bearer \" + auth_response.json()['access_token']\n",
-        "  refresh_body = {}\n",
-        "  refresh_body['refresh_token'] = auth_response.json()['refresh_token']\n",
-        "  start = time.time()\n",
-        "  print(\"Done. Successfully retrieved access token.\")"
-      ],
-      "metadata": {
-        "id": "1HHRCyWjwTdu"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "#@title { vertical-output: false, display-mode: \"form\" }\n",
-        "#@markdown **Code cell:** Run this to retrieve sensors and their zones available to you from the API\n",
-        "\n",
-        "#get hardware meta data\n",
-        "print(\"\\nRequesting metadata ...\")\n",
-        "api_url_base = 'https://beta.api.vivacitylabs.com'\n",
-        "hardware_request = requests.get(f'{api_url_base}/hardware/metadata', headers=headers)\n",
-        "if hardware_request.status_code == 401:\n",
-        "  print(\"\\n!Error: Can't access the data. Ask customer support if your user is setup correctly on API 3\\n\")\n",
-        "hardware = hardware_request.json()\n",
-        "\n",
-        "# Get hardware info\n",
-        "dict_hard = { \"hardware_id\" : [], \"sensor_name\" : [], \"zone_id\": [], \"zone_name\" : [], \"zonal_speed\" : [] }\n",
-        "for id in hardware:\n",
-        "  for lens in hardware[id][\"view_points\"]:\n",
-        "    for entity in hardware[id][\"view_points\"][lens]:\n",
-        "      #derive sensor name from first countline name\n",
-        "      if len(list(hardware[id][\"view_points\"][lens][\"countlines\"].keys())) == 0:\n",
-        "        cname = \"Unknown\"\n",
-        "      else:\n",
-        "        cid = list(hardware[id][\"view_points\"][lens][\"countlines\"].keys())[0]\n",
-        "        cname = hardware[id][\"view_points\"][lens][\"countlines\"][cid]['name']\n",
-        "      for zone_id in hardware[id][\"view_points\"][lens][\"zones\"]:\n",
-        "        dict_hard[\"hardware_id\"].append(id)\n",
-        "        dict_hard[\"sensor_name\"].append(cname)\n",
-        "        dict_hard[\"zone_id\"].append(zone_id)\n",
-        "        dict_hard[\"zone_name\"].append(hardware[id][\"view_points\"][lens][\"zones\"][zone_id]['name'])\n",
-        "        dict_hard[\"zonal_speed\"].append(hardware[id][\"view_points\"][lens][\"zones\"][zone_id]['is_occupancy'])\n",
-        "\n",
-        "#turn into dataframe and clean up\n",
-        "df_hard = pd.DataFrame.from_dict(dict_hard)\n",
-        "df_hard = df_hard[df_hard[\"zonal_speed\"] == True].drop_duplicates().reset_index(drop=True)\n",
-        "df_hard[\"sensor_name\"] = df_hard[\"sensor_name\"].str.split(\"_\")\n",
-        "for i in range(len(df_hard)):\n",
-        "  if len(df_hard[\"sensor_name\"].iloc[i])>1:\n",
-        "    df_hard[\"sensor_name\"].iloc[i] = df_hard[\"sensor_name\"].iloc[i][0] + \" \" + df_hard[\"sensor_name\"].iloc[i][1]\n",
-        "  else:\n",
-        "    df_hard[\"sensor_name\"].iloc[i] = df_hard[\"sensor_name\"].iloc[i]\n",
-        "\n",
-        "#create dropdown(\n",
-        "df_hard[\"zones_dropdown\"] = (df_hard[\"sensor_name\"].astype(str) + \" - \" + df_hard[\"zone_name\"].astype(str)\n",
-        "                             + \" (\" +  df_hard[\"zone_id\"].astype(str) + \")\")\n",
-        "print(\"Done. Successfully retrieved sensor metadata.\")"
-      ],
-      "metadata": {
-        "id": "arFChVrhyMu1"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Select zones and dates\n",
-        "Choose one or more zones, the classes you want data for, the date period and time bucket (15min, 1h, 24h).\n",
-        "\n",
-        "**Note:** The sensor name is derived from countline names (eg. countline name: S4_harleyRd_crossing => extracted sensor name: S4_harleyRd). Sometimes countlines are not named consistently resulting in odd sensor names."
-      ],
-      "metadata": {
-        "id": "xohjEFw-Ao6w"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "#@title { vertical-output: false, display-mode: \"form\" }\n",
-        "#@markdown **Code cell:** Run this and then make your selection below\n",
-        "box_layout = Layout(display='flex', flex_flow='column', align_items='stretch', border=None, width='28%')\n",
-        "\n",
-        "start_date_input = widgets.DatePicker(description=\"Start date\",layout=Layout(width='55%'))\n",
-        "end_date_input = widgets.DatePicker(description=\"End date\",layout=Layout(width='55%'))\n",
-        "timezone = widgets.Dropdown(options=['Europe/London', \"Europe/Berlin\", \"Australia/Sydney\"],description=\"Timezone\",layout=Layout(width='55%'))\n",
-        "timebucket_input = widgets.Dropdown(options=['15m', \"1h\", \"24h\"],description=\"Time bucket\",layout=Layout(width='55%'))\n",
-        "zones_input = widgets.SelectMultiple(\n",
-        "    options=df_hard[\"zones_dropdown\"].unique(),\n",
-        "    description='Zones',\n",
-        "    disabled=False,\n",
-        "    layout=Layout(width='auto', height='170px'))\n",
-        "class_input = widgets.SelectMultiple(\n",
-        "    options=[ \"cyclist\", \"motorbike\", \"car\", \"pedestrian\", \"taxi\", \"van\", \"minibus\", \"bus\", \"rigid\", \"truck\", \"emergency_car\", \"emergency_van\", \"fire_engine\", \"escooter\"],\n",
-        "    description='Class',  disabled=False,\n",
-        "    layout=Layout(width='55%', height='235px')\n",
-        ")\n",
-        "\n",
-        "items = [start_date_input, end_date_input, timezone,timebucket_input, class_input, zones_input]\n",
-        "box = Box(children=items, layout=box_layout)\n",
-        "printmd(\"**Select date period and zones**\")\n",
-        "printmd(\"Hold  `Ctrl`  to select multiple classes or zones\")\n",
-        "print(\"\")\n",
-        "box"
-      ],
-      "metadata": {
-        "id": "8TykxbMpjQz3"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Getting the data\n",
-        "\n",
-        "\n",
-        "We now query Classified Counts data from the API.\n",
-        "\n",
-        "The output will tell you how many requests are made and what the progress is.\n"
-      ],
-      "metadata": {
-        "id": "XfRqYcWv1BYd"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "#@title { vertical-output: false, display-mode: \"form\" }\n",
-        "#@markdown **Code cell:** Run this to set the API request parameters and check your selection again\n",
-        "params = {}\n",
-        "params['zone_ids'] = df_hard[df_hard[\"zones_dropdown\"].isin(zones_input.value)][\"zone_id\"].to_list()\n",
-        "params['classes'] = list(class_input.value)\n",
-        "print(params['classes'])\n",
-        "params[\"time_bucket\"] = timebucket_input.value\n",
-        "params['fill_nulls'] = \"true\"\n",
-        "\n",
-        "#convert local datetime to UTC datetime\n",
-        "start_date_utc = str(pd.to_datetime(start_date_input.value).tz_localize(timezone.value).astimezone(pytz.utc))\n",
-        "end_date_utc = str(pd.to_datetime(end_date_input.value).tz_localize(timezone.value).astimezone(pytz.utc))\n",
-        "\n",
-        "#check if dates are in correct order\n",
-        "if start_date_input.value > end_date_input.value:\n",
-        "  print(\"Start date is after end date, please correct your date selection\")\n",
-        "else:\n",
-        "  date_range = get_date_range(start_date_utc, end_date_utc)\n",
-        "  printmd(\"**Check your selection:**\\n\")\n",
-        "  print(\"Dates:\", start_date_input.value, \"to\", end_date_input.value, \"\\nClass:\", list(class_input.value),\n",
-        "        \"\\nZones:\", list(zones_input.value) , \"\\nTimebucket:\", timebucket_input.value)"
-      ],
-      "metadata": {
-        "id": "2vVFIKN0tgdH"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "#@title { vertical-output: false, display-mode: \"form\" }\n",
-        "#@markdown **Code cell:** Run this to request data from the API (can take a bit)\n",
-        "\n",
-        "data = []\n",
-        "for i,date in enumerate(date_range):\n",
-        "  time_elapsed = (time.time() - start)\n",
-        "  if time_elapsed > 500:\n",
-        "    print(\"Reauthorising...\")\n",
-        "    auth_response = requests.post(\"https://api.vivacitylabs.com/refresh-token\", data=refresh_body, headers={'Content-Type':'application/x-www-form-urlencoded'})\n",
-        "    headers = {}\n",
-        "    headers['Authorization'] = \"Bearer \" + auth_response.json()['access_token']\n",
-        "    refresh_body = {}\n",
-        "    refresh_body['refresh_token'] = auth_response.json()['refresh_token']\n",
-        "    start = time.time()\n",
-        "    print(\"Done.\")\n",
-        "  params[\"from\"] = date[0]\n",
-        "  params[\"to\"] = date[1]\n",
-        "  response = requests.get('https://beta.api.vivacitylabs.com/zone/occupancy', params=params, headers=headers)\n",
-        "  print(str(i+1) + \"/\" + str(len(date_range)) + \": \" + str(response.status_code) + \" \" + response.reason)\n",
-        "  if response.status_code is 200:\n",
-        "    occ_json = response.json()\n",
-        "    occ_dict = {\"zone_id\":[], \"from\":[], \"to\":[], \"class\":[], \"total_count\":[], \"stopped_count\":[]}\n",
-        "\n",
-        "    for zone, items in occ_json.items():\n",
-        "            for time_bucket in items:\n",
-        "                for _class in time_bucket['class_occupancies'].keys():\n",
-        "                    occ_dict[\"zone_id\"].append(zone)\n",
-        "                    occ_dict[\"from\"].append(datetime.strptime(time_bucket['from'],'%Y-%m-%dT%H:%M:%S.000Z'))\n",
-        "                    occ_dict[\"to\"].append(datetime.strptime(time_bucket['to'],'%Y-%m-%dT%H:%M:%S.000Z'))\n",
-        "                    occ_dict[\"class\"].append(_class)\n",
-        "                    occ_dict[\"total_count\"].append(time_bucket['class_occupancies'][_class][\"total\"])\n",
-        "                    occ_dict[\"stopped_count\"].append(time_bucket['class_occupancies'][_class][\"stopped\"])\n",
-        "\n",
-        "    occ_df = pd.DataFrame.from_dict(occ_dict)\n",
-        "    data.append(occ_df)\n",
-        "\n",
-        "  else:\n",
-        "    print(\"Data missing for \" + params[\"timeFrom\"].split(\"T\")[0] + \" to \" + params[\"timeTo\"].split(\"T\")[0])\n",
-        "  time.sleep(1)\n",
-        "\n",
-        "data = pd.concat(data, axis=0, ignore_index=True)"
-      ],
-      "metadata": {
-        "id": "GXf_4K-yTYgc"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Stage 3: Data Processing\n",
-        "Now we process the raw data output, this might take a bit depending on the size of your data set."
-      ],
-      "metadata": {
-        "id": "CnI-EFqr0nxu"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "#@title  { vertical-output: false, display-mode: \"form\" }\n",
-        "#@markdown **Code cell:** Run to process data\n",
-        "\n",
-        "if timebucket_input.value==\"15m\":\n",
-        "  seconds = 15*60\n",
-        "elif timebucket_input.value== \"1h\":\n",
-        "  seconds = 60*60\n",
-        "else:\n",
-        "  seconds = 24*60*60\n",
-        "\n",
-        "#calculate mean objects per second\n",
-        "mean_objects_second = []\n",
-        "for i in range(len(data)):\n",
-        "  sum = 0\n",
-        "  for items in data.iloc[i][\"total_count\"].items():\n",
-        "    sum +=int(items[0])*items[1]\n",
-        "  mean_objects_second.append(round(sum/seconds,4))\n",
-        "data[\"mean_objects_second\"] = mean_objects_second\n",
-        "\n",
-        "mean_stopped_second = []\n",
-        "for i in range(len(data)):\n",
-        "  sum = 0\n",
-        "  for items in data.iloc[i][\"stopped_count\"].items():\n",
-        "    sum +=int(items[0])*items[1]\n",
-        "  mean_stopped_second.append(round(sum/seconds,4))\n",
-        "data[\"mean_stopped_objects_second\"] = mean_stopped_second\n",
-        "\n",
-        "#convert back to local datetime\n",
-        "data[\"Date\"] = [ str(pd.to_datetime(i).tz_localize('utc').astimezone(timezone.value).date()) for i in data[\"from\"]]\n",
-        "data[\"Start time\"] = [ str(pd.to_datetime(i).tz_localize('utc').astimezone(timezone.value).time()) for i in data[\"from\"]]\n",
-        "data[\"End time\"] = [ str(pd.to_datetime(i).tz_localize('utc').astimezone(timezone.value).time()) for i in data[\"to\"]]\n",
-        "\n",
-        "#merge in zone name\n",
-        "data = pd.merge(data, df_hard[[\"zone_id\", \"zones_dropdown\"]], left_on=\"zone_id\", right_on=\"zone_id\", how='left')\n",
-        "\n",
-        "#rename and reorder columns\n",
-        "data = data.rename(columns={\"zones_dropdown\":\"zone_description\"})\n",
-        "export = data[[ 'Date','Start time', 'End time','zone_id', 'zone_description','class', 'total_count', 'stopped_count',\n",
-        "       'mean_objects_second', 'mean_stopped_objects_second' ]]"
-      ],
-      "metadata": {
-        "id": "Sr0Lt1_YVB1R"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Stage 4: Data Export\n",
-        "Now let's write this to a .csv file. You can either save the file locally (it will show in your Downloads folder) or save it to a Google Drive.\n",
-        "\n",
-        "\n",
-        "* **Local Downloads Folder:** This might not work if your browser or computer blocking downloads.\n",
-        "* **Google Drive:** If you want to save it in Google Drive, you will be asked for permission to connect to your Google Account."
-      ],
-      "metadata": {
-        "id": "9YNEW3qFGykk"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "#@title  { vertical-output: true, display-mode: \"form\" }\n",
-        "#@markdown Select where to save the csv file\n",
-        "download_location = \"Local folder\" #@param [ \"Local folder\", \"Google Drive\"]\n",
-        "#@markdown Name your file\n",
-        "filename = \"occupancy-test\" #@param {type:\"string\"}\n",
-        "#@markdown Hit run (>)\n",
-        "\n",
-        "if download_location == \"Local folder\":\n",
-        "  from google.colab import files\n",
-        "  export.to_csv(filename + \".csv\", index = False)\n",
-        "  files.download(filename + \".csv\")\n",
-        "else:\n",
-        "  from google.colab import drive\n",
-        "  drive.mount('/content/drive')\n",
-        "  path = '/content/drive/My Drive/'\n",
-        "  export.to_csv(path + filename +\".csv\", index = False)"
-      ],
-      "metadata": {
-        "id": "H_M2lLv6Poaq"
-      },
-      "execution_count": null,
-      "outputs": []
-    }
-  ]
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "view-in-github",
+    "colab_type": "text"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/vivacitylabs/data-toolkit/blob/master/notebooks/occupancy_bulk_download_generator.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Occupancy - Bulk Download Generator\n",
+    "\n"
+   ],
+   "metadata": {
+    "id": "swMyhc_6p4SZ"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Generate a csv file of zonal occupancy data over multiple days"
+   ],
+   "metadata": {
+    "id": "f4ZN3B2nO3_1"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "This notebook is a tool to access VivaCity data via the API. It is aimed as an **interim solution** while we're working on new dashboard developments. You can contact customer support if you have any issues (support@vivacitylabs.com) or raise a ticked on the [Customer Help Portal](https://vivacitylabs.atlassian.net/servicedesk/customer/portal/16)."
+   ],
+   "metadata": {
+    "id": "rPUGheZbGhnG"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "#### How it works"
+   ],
+   "metadata": {
+    "id": "owGXUfxaRzlG"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "This notebook will run you through all the necessary steps and will save a csv file locally or in your Google Drive.\n",
+    "\n",
+    "You will need to fill in a few details and then hit the run button (\u25b6) next to the code cells.\n",
+    "\n",
+    "If you want to make changes to the code and save them, you will first need to save a copy of this notebook to your Google Drive.\n",
+    "\n"
+   ],
+   "metadata": {
+    "id": "waNUJf0ZOFHa"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "**What you will need**\n",
+    "\n",
+    "- VivaCity API login credentials\n",
+    "- Sensors and their zones you want to download data for\n",
+    "\n",
+    "\n",
+    "\n",
+    "\u2139  Note the notebook only works for zones that have [occupancy](https://vivacitylabs.customerly.help/vivacity-dashboard/occupancy) enabled\n"
+   ],
+   "metadata": {
+    "id": "bl3aEsarmxD_"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "#### Output format"
+   ],
+   "metadata": {
+    "id": "Xi8YdeTmRwNr"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "You will receive occupancy measures in selected time buckets in the following format. The mean objects and mean stopped objects per second are derived from the `total_count` and `stopped_count` columns. For an explanation on those, read the API documentation [here](https://beta.docs.api.vivacitylabs.com/)."
+   ],
+   "metadata": {
+    "id": "I9ryHNRfRjWw"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "\n",
+    "| Start Date | Start time | End time | zone_id |  zone_description | \tclass |\ttotal_count|\tstopped_count |\tmean_objects_second |\tmean_stopped_objects_second |\n",
+    "|:---------:|:---------:|:---------:|:---------:|:---------:|:---------:|:---------:|:---------:|:---------:|:---------:|\n",
+    "| 2022-10-17 |00:00:00\t| 00:15:00 |\t2245 | S4 GrandDrive - Zone 1 (2245) | car\t|{'1': 20}|{}|\t0.0056 |\t0.0000\t|\n",
+    "\n"
+   ],
+   "metadata": {
+    "id": "lmzYubsdPDFg"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Stage 1: Getting Started\n",
+    "Let's begin by importing the packages we'll need and creating some useful functions!\n",
+    "\n",
+    "Hit the run button (\u25b6) in the top left corner."
+   ],
+   "metadata": {
+    "id": "p-2otBZMqfTH"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "#@title { vertical-output: false, display-mode: \"form\" }\n",
+    "#@markdown **Code cell:** Run this to import functions and connect to Google Drive\n",
+    "import requests\n",
+    "import getpass\n",
+    "import json\n",
+    "from datetime import date, datetime, timedelta\n",
+    "import pytz\n",
+    "import pandas as pd\n",
+    "import csv\n",
+    "import time\n",
+    "from IPython.display import Markdown, display\n",
+    "def printmd(string):\n",
+    "    display(Markdown(string))\n",
+    "from ipywidgets import interact, interactive, fixed, interact_manual, Layout, Box\n",
+    "import ipywidgets as widgets\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "\n",
+    "def get_date_range(start_date, end_date):\n",
+    "    start_dates = []\n",
+    "    end_dates = []\n",
+    "\n",
+    "    start_date = datetime.fromisoformat(start_date)\n",
+    "    end_date = datetime.fromisoformat(end_date)\n",
+    "    while True:\n",
+    "        start_dates.append(start_date.strftime('%Y-%m-%dT%H:%M:%S.000Z'))\n",
+    "        end_dates.append((start_date+timedelta(days=1)).strftime('%Y-%m-%dT%H:%M:%S.000Z'))\n",
+    "        start_date = start_date+timedelta(days=1)\n",
+    "        if start_date > end_date:\n",
+    "            break\n",
+    "    date_range = list(zip(start_dates, end_dates))\n",
+    "    return date_range"
+   ],
+   "metadata": {
+    "id": "UXc72Xjuqikg"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Stage 2: Data Import\n",
+    "At the end of this process we will requested data from the API for the dates in the range that you have determined in the **Zone Details** step.\n",
+    "\n",
+    "The resulting JSON responses will then be converted into a data table in the **Data Processing** step.\n",
+    "\n",
+    "Authentication is handled at this stage."
+   ],
+   "metadata": {
+    "id": "ceKN_3fHqlP6"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Authentication\n",
+    "You'll need a VivaCity API key. You can create one in the [User Settings page](https://admin.vivacitylabs.com/settings/api-access). If you have any issues, please contact customer support (support@vivacitylabs.com).\n",
+    "\n",
+    "1.   Insert your API key into the box on the right.\n",
+    "2.   Hit the run button (\u25b6).\n"
+   ],
+   "metadata": {
+    "id": "zSCZ0-x1tf0l"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "#@title  { run: \"auto\", vertical-output: true, display-mode: \"form\" }\n",
+    "#@markdown **Code cell:** Insert your API key, then run\n",
+    "\n",
+    "api_key = \"api-key\" #@param {type:\"string\"}\n",
+    "\n",
+    "headers = {\n",
+    "    'Accept': 'application/json',\n",
+    "    'x-vivacity-api-key': api_key\n",
+    "}"
+   ],
+   "metadata": {
+    "id": "i8mP6EzKE-MX"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Retrieve available sensors and zones\n",
+    "\n",
+    "We'll now get all sensors and their zones the API user has access to (which have occupancy enabled)."
+   ],
+   "metadata": {
+    "id": "wEu2avZvwMDx"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "#@title { vertical-output: false, display-mode: \"form\" }\n",
+    "#@markdown **Code cell:** Run this to retrieve zones available to you from the API\n",
+    "\n",
+    "print(\"Requesting zone metadata ...\")\n",
+    "api_url_base = 'https://api.vivacitylabs.com'\n",
+    "\n",
+    "# Use a Session with retries to handle the occasional chunked-encoding hiccup on large metadata responses\n",
+    "session = requests.Session()\n",
+    "session.headers.update(headers)\n",
+    "\n",
+    "zone_metadata = {}\n",
+    "cursor = None\n",
+    "page_size = 1000\n",
+    "while True:\n",
+    "    params_meta = {'page_size': page_size}\n",
+    "    if cursor:\n",
+    "        params_meta['cursor'] = cursor\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            r = session.get(f'{api_url_base}/zone/metadata', params=params_meta, timeout=120)\n",
+    "            break\n",
+    "        except requests.exceptions.RequestException as e:\n",
+    "            last_err = e\n",
+    "            time.sleep(2 ** attempt)\n",
+    "    else:\n",
+    "        raise RuntimeError(f\"Failed to fetch zone metadata after retries: {last_err}\")\n",
+    "\n",
+    "    if r.status_code == 401:\n",
+    "        print(\"\\n!Error: Can't access the data. Check your API key, or ask customer support if your user is set up correctly.\\n\")\n",
+    "        raise SystemExit\n",
+    "    r.raise_for_status()\n",
+    "    body = r.json()\n",
+    "\n",
+    "    # Endpoint returns either a flat dict {zone_id: {...}} or a paged dict {data: {...}, next_cursor: ...}\n",
+    "    if isinstance(body, dict) and 'data' in body and isinstance(body['data'], dict):\n",
+    "        zone_metadata.update(body['data'])\n",
+    "        cursor = body.get('next_cursor') or body.get('cursor')\n",
+    "        if not cursor:\n",
+    "            break\n",
+    "    else:\n",
+    "        zone_metadata.update(body)\n",
+    "        break\n",
+    "\n",
+    "# Filter to occupancy-enabled zones\n",
+    "dict_zones = {\"zone_id\": [], \"zone_name\": [], \"zone_description\": []}\n",
+    "for zone_id, z in zone_metadata.items():\n",
+    "    if not isinstance(z, dict):\n",
+    "        continue\n",
+    "    if not z.get('is_occupancy'):\n",
+    "        continue\n",
+    "    dict_zones[\"zone_id\"].append(zone_id)\n",
+    "    dict_zones[\"zone_name\"].append(z.get('name', ''))\n",
+    "    dict_zones[\"zone_description\"].append(z.get('description', ''))\n",
+    "\n",
+    "df_hard = pd.DataFrame.from_dict(dict_zones).drop_duplicates().reset_index(drop=True)\n",
+    "\n",
+    "# Build a human-readable dropdown label: \"name - description (zone_id)\" (omit description if empty)\n",
+    "def _label(row):\n",
+    "    if row['zone_description']:\n",
+    "        return f\"{row['zone_name']} - {row['zone_description']} ({row['zone_id']})\"\n",
+    "    return f\"{row['zone_name']} ({row['zone_id']})\"\n",
+    "df_hard[\"zones_dropdown\"] = df_hard.apply(_label, axis=1)\n",
+    "df_hard = df_hard.sort_values(\"zones_dropdown\").reset_index(drop=True)\n",
+    "\n",
+    "print(f\"Done. {len(df_hard)} occupancy-enabled zones available.\")"
+   ],
+   "metadata": {
+    "id": "1HHRCyWjwTdu"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Select zones and dates\n",
+    "Choose one or more zones, the classes you want data for, the date period and time bucket (15min, 1h, 24h).\n",
+    "\n",
+    "**Note:** The sensor name is derived from countline names (eg. countline name: S4_harleyRd_crossing => extracted sensor name: S4_harleyRd). Sometimes countlines are not named consistently resulting in odd sensor names."
+   ],
+   "metadata": {
+    "id": "xohjEFw-Ao6w"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "#@title { vertical-output: false, display-mode: \"form\" }\n",
+    "#@markdown **Code cell:** Run this and then make your selection below\n",
+    "box_layout = Layout(display='flex', flex_flow='column', align_items='stretch', border=None, width='28%')\n",
+    "\n",
+    "start_date_input = widgets.DatePicker(description=\"Start date\",layout=Layout(width='55%'))\n",
+    "end_date_input = widgets.DatePicker(description=\"End date\",layout=Layout(width='55%'))\n",
+    "timezone = widgets.Dropdown(options=['Europe/London', \"Europe/Berlin\", \"Australia/Sydney\"],description=\"Timezone\",layout=Layout(width='55%'))\n",
+    "timebucket_input = widgets.Dropdown(options=['15m', \"1h\", \"24h\"],description=\"Time bucket\",layout=Layout(width='55%'))\n",
+    "zones_input = widgets.SelectMultiple(\n",
+    "    options=df_hard[\"zones_dropdown\"].unique(),\n",
+    "    description='Zones',\n",
+    "    disabled=False,\n",
+    "    layout=Layout(width='auto', height='170px'))\n",
+    "class_input = widgets.SelectMultiple(\n",
+    "    options=[ \"cyclist\", \"motorbike\", \"car\", \"pedestrian\", \"taxi\", \"van\", \"minibus\", \"bus\", \"rigid\", \"truck\", \"emergency_car\", \"emergency_van\", \"fire_engine\", \"escooter\"],\n",
+    "    description='Class',  disabled=False,\n",
+    "    layout=Layout(width='55%', height='235px')\n",
+    ")\n",
+    "\n",
+    "items = [start_date_input, end_date_input, timezone,timebucket_input, class_input, zones_input]\n",
+    "box = Box(children=items, layout=box_layout)\n",
+    "printmd(\"**Select date period and zones**\")\n",
+    "printmd(\"Hold  `Ctrl`  to select multiple classes or zones\")\n",
+    "print(\"\")\n",
+    "box"
+   ],
+   "metadata": {
+    "id": "8TykxbMpjQz3"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Getting the data\n",
+    "\n",
+    "\n",
+    "We now query occupancy data from the API.\n",
+    "\n",
+    "The output will tell you how many requests are made and what the progress is.\n"
+   ],
+   "metadata": {
+    "id": "XfRqYcWv1BYd"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "#@title { vertical-output: false, display-mode: \"form\" }\n",
+    "#@markdown **Code cell:** Run this to set the API request parameters and check your selection again\n",
+    "params = {}\n",
+    "params['zone_ids'] = df_hard[df_hard[\"zones_dropdown\"].isin(zones_input.value)][\"zone_id\"].to_list()\n",
+    "params['classes'] = list(class_input.value)\n",
+    "print(params['classes'])\n",
+    "params[\"time_bucket\"] = timebucket_input.value\n",
+    "params['fill_nulls'] = \"true\"\n",
+    "\n",
+    "#convert local datetime to UTC datetime\n",
+    "start_date_utc = str(pd.to_datetime(start_date_input.value).tz_localize(timezone.value).astimezone(pytz.utc))\n",
+    "end_date_utc = str(pd.to_datetime(end_date_input.value).tz_localize(timezone.value).astimezone(pytz.utc))\n",
+    "\n",
+    "#check if dates are in correct order\n",
+    "if start_date_input.value > end_date_input.value:\n",
+    "  print(\"Start date is after end date, please correct your date selection\")\n",
+    "else:\n",
+    "  date_range = get_date_range(start_date_utc, end_date_utc)\n",
+    "  printmd(\"**Check your selection:**\\n\")\n",
+    "  print(\"Dates:\", start_date_input.value, \"to\", end_date_input.value, \"\\nClass:\", list(class_input.value),\n",
+    "        \"\\nZones:\", list(zones_input.value) , \"\\nTimebucket:\", timebucket_input.value)"
+   ],
+   "metadata": {
+    "id": "2vVFIKN0tgdH"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "#@title { vertical-output: false, display-mode: \"form\" }\n",
+    "#@markdown **Code cell:** Run this to request data from the API (can take a bit)\n",
+    "\n",
+    "# Rate limits: 300 requests/minute and 7200 requests/hour per source IP.\n",
+    "# We stay safely below both with sliding-window tracking and a small minimum gap between requests.\n",
+    "from collections import deque\n",
+    "\n",
+    "max_requests_per_minute = 290\n",
+    "max_requests_per_hour = 7100\n",
+    "min_request_interval = 60 / max_requests_per_minute\n",
+    "\n",
+    "minute_window = deque()\n",
+    "hour_window = deque()\n",
+    "\n",
+    "def wait_for_rate_limit():\n",
+    "    \"\"\"Block until we're safely under both per-minute and per-hour API limits.\"\"\"\n",
+    "    now = time.time()\n",
+    "    while minute_window and now - minute_window[0] > 60:\n",
+    "        minute_window.popleft()\n",
+    "    while hour_window and now - hour_window[0] > 3600:\n",
+    "        hour_window.popleft()\n",
+    "\n",
+    "    if len(minute_window) >= max_requests_per_minute:\n",
+    "        sleep_time = 60 - (now - minute_window[0]) + 0.05\n",
+    "        if sleep_time > 0:\n",
+    "            time.sleep(sleep_time)\n",
+    "    if len(hour_window) >= max_requests_per_hour:\n",
+    "        sleep_time = 3600 - (time.time() - hour_window[0]) + 0.05\n",
+    "        if sleep_time > 0:\n",
+    "            print(f\"Hourly rate limit reached, sleeping {sleep_time:.0f}s ...\")\n",
+    "            time.sleep(sleep_time)\n",
+    "\n",
+    "    if minute_window:\n",
+    "        time_since_last = time.time() - minute_window[-1]\n",
+    "        if time_since_last < min_request_interval:\n",
+    "            time.sleep(min_request_interval - time_since_last)\n",
+    "\n",
+    "data = []\n",
+    "for i, date in enumerate(date_range):\n",
+    "    params[\"from\"] = date[0]\n",
+    "    params[\"to\"] = date[1]\n",
+    "\n",
+    "    wait_for_rate_limit()\n",
+    "\n",
+    "    # Retry transient failures (429, 5xx) with exponential backoff\n",
+    "    response = None\n",
+    "    for attempt in range(5):\n",
+    "        request_time = time.time()\n",
+    "        minute_window.append(request_time)\n",
+    "        hour_window.append(request_time)\n",
+    "        try:\n",
+    "            response = requests.get(\n",
+    "                'https://api.vivacitylabs.com/zone/occupancy',\n",
+    "                params=params, headers=headers, timeout=60\n",
+    "            )\n",
+    "        except requests.exceptions.RequestException as e:\n",
+    "            print(f\"Request error on attempt {attempt+1}: {e}\")\n",
+    "            time.sleep(2 ** attempt)\n",
+    "            continue\n",
+    "        if response.status_code == 429:\n",
+    "            retry_after = int(response.headers.get('Retry-After', 2 ** attempt))\n",
+    "            print(f\"Rate limited (429). Sleeping {retry_after}s before retry.\")\n",
+    "            time.sleep(retry_after)\n",
+    "            continue\n",
+    "        if 500 <= response.status_code < 600:\n",
+    "            print(f\"Server error {response.status_code} on attempt {attempt+1}. Retrying...\")\n",
+    "            time.sleep(2 ** attempt)\n",
+    "            continue\n",
+    "        break\n",
+    "\n",
+    "    print(f\"{i+1}/{len(date_range)}: {response.status_code if response is not None else 'no-response'} {response.reason if response is not None else ''}\")\n",
+    "\n",
+    "    if response is None:\n",
+    "        print(f\"Skipped {date[0]} to {date[1]} after retries failed\")\n",
+    "        continue\n",
+    "\n",
+    "    if response.status_code == 200:\n",
+    "        occ_json = response.json()\n",
+    "        occ_dict = {\"zone_id\":[], \"from\":[], \"to\":[], \"class\":[], \"total_count\":[], \"stopped_count\":[]}\n",
+    "\n",
+    "        for zone, items in occ_json.items():\n",
+    "            for time_bucket in items:\n",
+    "                for _class in time_bucket['class_occupancies'].keys():\n",
+    "                    occ_dict[\"zone_id\"].append(zone)\n",
+    "                    occ_dict[\"from\"].append(datetime.strptime(time_bucket['from'],'%Y-%m-%dT%H:%M:%S.000Z'))\n",
+    "                    occ_dict[\"to\"].append(datetime.strptime(time_bucket['to'],'%Y-%m-%dT%H:%M:%S.000Z'))\n",
+    "                    occ_dict[\"class\"].append(_class)\n",
+    "                    occ_dict[\"total_count\"].append(time_bucket['class_occupancies'][_class][\"total\"])\n",
+    "                    occ_dict[\"stopped_count\"].append(time_bucket['class_occupancies'][_class][\"stopped\"])\n",
+    "\n",
+    "        if any(len(v) > 0 for v in occ_dict.values()):\n",
+    "            data.append(pd.DataFrame.from_dict(occ_dict))\n",
+    "    elif response.status_code == 204:\n",
+    "        # No content for this period - normal when there is no data\n",
+    "        pass\n",
+    "    else:\n",
+    "        print(f\"Data missing for {date[0].split('T')[0]} to {date[1].split('T')[0]}: {response.text[:200]}\")\n",
+    "\n",
+    "if data:\n",
+    "    data = pd.concat(data, axis=0, ignore_index=True)\n",
+    "    print(f\"\\nCollected {len(data)} rows.\")\n",
+    "else:\n",
+    "    data = pd.DataFrame()\n",
+    "    print(\"\\nNo data was collected.\")"
+   ],
+   "metadata": {
+    "id": "GXf_4K-yTYgc"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Stage 3: Data Processing\n",
+    "Now we process the raw data output, this might take a bit depending on the size of your data set."
+   ],
+   "metadata": {
+    "id": "CnI-EFqr0nxu"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "#@title  { vertical-output: false, display-mode: \"form\" }\n",
+    "#@markdown **Code cell:** Run to process data\n",
+    "\n",
+    "if timebucket_input.value==\"15m\":\n",
+    "  seconds = 15*60\n",
+    "elif timebucket_input.value== \"1h\":\n",
+    "  seconds = 60*60\n",
+    "else:\n",
+    "  seconds = 24*60*60\n",
+    "\n",
+    "#calculate mean objects per second\n",
+    "mean_objects_second = []\n",
+    "for i in range(len(data)):\n",
+    "  sum = 0\n",
+    "  for items in data.iloc[i][\"total_count\"].items():\n",
+    "    sum +=int(items[0])*items[1]\n",
+    "  mean_objects_second.append(round(sum/seconds,4))\n",
+    "data[\"mean_objects_second\"] = mean_objects_second\n",
+    "\n",
+    "mean_stopped_second = []\n",
+    "for i in range(len(data)):\n",
+    "  sum = 0\n",
+    "  for items in data.iloc[i][\"stopped_count\"].items():\n",
+    "    sum +=int(items[0])*items[1]\n",
+    "  mean_stopped_second.append(round(sum/seconds,4))\n",
+    "data[\"mean_stopped_objects_second\"] = mean_stopped_second\n",
+    "\n",
+    "#convert back to local datetime\n",
+    "data[\"Date\"] = [ str(pd.to_datetime(i).tz_localize('utc').astimezone(timezone.value).date()) for i in data[\"from\"]]\n",
+    "data[\"Start time\"] = [ str(pd.to_datetime(i).tz_localize('utc').astimezone(timezone.value).time()) for i in data[\"from\"]]\n",
+    "data[\"End time\"] = [ str(pd.to_datetime(i).tz_localize('utc').astimezone(timezone.value).time()) for i in data[\"to\"]]\n",
+    "\n",
+    "#merge in zone name\n",
+    "data = pd.merge(data, df_hard[[\"zone_id\", \"zones_dropdown\"]], left_on=\"zone_id\", right_on=\"zone_id\", how='left')\n",
+    "\n",
+    "#rename and reorder columns\n",
+    "data = data.rename(columns={\"zones_dropdown\":\"zone_description\"})\n",
+    "export = data[[ 'Date','Start time', 'End time','zone_id', 'zone_description','class', 'total_count', 'stopped_count',\n",
+    "       'mean_objects_second', 'mean_stopped_objects_second' ]]"
+   ],
+   "metadata": {
+    "id": "Sr0Lt1_YVB1R"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Stage 4: Data Export\n",
+    "Now let's write this to a .csv file. You can either save the file locally (it will show in your Downloads folder) or save it to a Google Drive.\n",
+    "\n",
+    "\n",
+    "* **Local Downloads Folder:** This might not work if your browser or computer blocking downloads.\n",
+    "* **Google Drive:** If you want to save it in Google Drive, you will be asked for permission to connect to your Google Account."
+   ],
+   "metadata": {
+    "id": "9YNEW3qFGykk"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "#@title  { vertical-output: true, display-mode: \"form\" }\n",
+    "#@markdown Select where to save the csv file\n",
+    "download_location = \"Local folder\" #@param [ \"Local folder\", \"Google Drive\"]\n",
+    "#@markdown Name your file\n",
+    "filename = \"occupancy-test\" #@param {type:\"string\"}\n",
+    "#@markdown Hit run (>)\n",
+    "\n",
+    "if download_location == \"Local folder\":\n",
+    "  from google.colab import files\n",
+    "  export.to_csv(filename + \".csv\", index = False)\n",
+    "  files.download(filename + \".csv\")\n",
+    "else:\n",
+    "  from google.colab import drive\n",
+    "  drive.mount('/content/drive')\n",
+    "  path = '/content/drive/My Drive/'\n",
+    "  export.to_csv(path + filename +\".csv\", index = False)"
+   ],
+   "metadata": {
+    "id": "H_M2lLv6Poaq"
+   },
+   "execution_count": null,
+   "outputs": []
+  }
+ ]
 }


### PR DESCRIPTION
Switch authentication from the deprecated username/password + /get-token flow to API key auth via the x-vivacity-api-key header, matching the classified counts and other recently updated notebooks.

Other changes:
- Use /zone/metadata (paginated) instead of /hardware/metadata, which reliably hit ChunkedEncodingError on large estates.
- Move from beta.api.vivacitylabs.com to api.vivacitylabs.com.
- Drop the 500s token-refresh loop (API keys don't expire).
- Add sliding-window rate limiting honoring both documented limits (300/min and 7200/hour) with exponential backoff on 429/5xx.
- Fix `is 200` -> `== 200` and an unreachable `params["timeFrom"]`.